### PR TITLE
GPII-3672: Initial take on certmerge-operator Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+stages:
+  - build
+
+build-push-master:
+  stage: build
+  script:
+    - make build
+    - make push
+  only:
+    refs:
+      - master
+
+build-push-tag:
+  stage: build
+  script:
+    - make build-tag
+    - make push-tag
+  only:
+    - tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM golang:1.11.5-alpine3.8 AS build
+
+ENV CERTMERGE_RELEASE=v0.0.3 \
+    CERTMERGE_PROJECT=github.com/prune998/certmerge-operator \
+    OPERATOR_SDK_RELEASE=v0.4.0 \
+    OPERATOR_SDK_PROJECT=github.com/operator-framework/operator-sdk \
+    DEP_VERSION=v0.5.0 \
+    DEP_SHA=287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f83 \
+    CGO_ENABLED=0 \
+    LANG=C.UTF-8
+
+ENV CERTMERGE_GIT_REPO=https://${CERTMERGE_PROJECT}.git \
+    OPERATOR_SDK_GIT_REPO=https://${OPERATOR_SDK_PROJECT}.git \
+    DEP_URL=https://github.com/golang/dep/releases/download/${DEP_VERSION}/dep-linux-amd64
+
+RUN apk add --update --no-cache \
+      curl \
+      git \
+      make \
+    && curl -LsS "${DEP_URL}" -o /usr/bin/dep \
+    && echo "${DEP_SHA}  /usr/bin/dep" |  sha256sum -c - \
+    && chmod +x /usr/bin/dep \
+    && git clone --branch "${OPERATOR_SDK_RELEASE}" --depth=1 -- "${OPERATOR_SDK_GIT_REPO}" "${GOPATH}/src/${OPERATOR_SDK_PROJECT}" \
+    && cd "${GOPATH}/src/${OPERATOR_SDK_PROJECT}" \
+    && make dep \
+    && make install \
+    && git clone --branch "${CERTMERGE_RELEASE}" --depth=1 -- "${CERTMERGE_GIT_REPO}" "${GOPATH}/src/${CERTMERGE_PROJECT}" \
+    && cd "${GOPATH}/src/${CERTMERGE_PROJECT}" \
+    && operator-sdk generate k8s \
+    && go build -o /certmerge-operator cmd/manager/main.go
+
+
+FROM scratch
+
+ENV CERTMERGE_UID=10000 \
+    CERTMERGE_GID=10000
+
+COPY --from=build /certmerge-operator /certmerge-operator
+
+USER ${CERTMERGE_UID}:${CERTMERGE_GID}
+
+CMD ["/certmerge-operator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM golang:1.11.5-alpine3.8 AS build
 
 ENV CERTMERGE_RELEASE=v0.0.3 \
     CERTMERGE_PROJECT=github.com/prune998/certmerge-operator \
+    CERTMERGE_GIT_SHA=20ed30cb4f5acb17f0efeb222acfba3962ab0dd9 \
     OPERATOR_SDK_RELEASE=v0.4.0 \
     OPERATOR_SDK_PROJECT=github.com/operator-framework/operator-sdk \
+    OPERATOR_SDK_GIT_SHA=cc5fe885869c181d820557bd296f092637fa70af \
     DEP_VERSION=v0.5.0 \
     DEP_SHA=287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f83 \
     CGO_ENABLED=0 \
@@ -22,10 +24,12 @@ RUN apk add --update --no-cache \
     && chmod +x /usr/bin/dep \
     && git clone --branch "${OPERATOR_SDK_RELEASE}" --depth=1 -- "${OPERATOR_SDK_GIT_REPO}" "${GOPATH}/src/${OPERATOR_SDK_PROJECT}" \
     && cd "${GOPATH}/src/${OPERATOR_SDK_PROJECT}" \
+    && git show-ref --verify HEAD | grep -q "^${OPERATOR_SDK_GIT_SHA}" \
     && make dep \
     && make install \
     && git clone --branch "${CERTMERGE_RELEASE}" --depth=1 -- "${CERTMERGE_GIT_REPO}" "${GOPATH}/src/${CERTMERGE_PROJECT}" \
     && cd "${GOPATH}/src/${CERTMERGE_PROJECT}" \
+    && git show-ref --verify HEAD | grep -q "^${CERTMERGE_GIT_SHA}" \
     && operator-sdk generate k8s \
     && go build -o /certmerge-operator cmd/manager/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: help build build-tag push 
+.DEFAULT_GOAL:= help
+.ONESHELL:
+
+DOCKER_IMAGE = gpii/certmerge-operator
+
+help:                     ## Prints list of tasks
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' Makefile
+
+build:                    ## Build image as latest
+	docker build -t "${DOCKER_IMAGE}:latest" ./
+
+build-tag:                ## Build image as tag (use CI_COMMIT_TAG env var)
+	@CI_COMMIT_TAG="$${CI_COMMIT_TAG:?Required variable not set}"
+	docker build -t "${DOCKER_IMAGE}:${CI_COMMIT_TAG}" ./
+
+push:                     ## Push image - latest
+	docker push "${DOCKER_IMAGE}:latest"
+
+push-tag:                 ## Push image - tag
+	@CI_COMMIT_TAG="$${CI_COMMIT_TAG:?Required variable not set}"
+	docker push "${DOCKER_IMAGE}:${CI_COMMIT_TAG}"
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# certmerge-operator Docker image
+# docker-image-certmerge-operator
+
+This is Docker image build of certmerge-operator
+(https://github.com/prune998/certmerge-operator). Certmerge-operator is a
+Kubernetes Operator that can merge many TLS secrets inside one Opaque secrets.
+This is required for using Istio Gateway with more than one TLS certificate.
+
+## Building
+
+### Master
+
+On push/merge to master, CI will automatically build and push
+`gpii/certmerge-operator:latest` image.
+
+### Tags
+
+Create and push git tag and CI will build and publish corresponding`
+`gpii/certmerge-operator:${git_tag}` docker image.
+
+#### Tag format
+
+Tags should follow actual certmerge-operator version, suffixed by
+`-gpii.${gpii_build_number}`, where `gpii_build_number` is monotonically
+increasing number denoting Docker image build number,  starting from `0`
+for each upstream version.
+
+Example:
+```
+0.0.3-gpii.0
+0.0.3-gpii.1
+...
+0.0.4-gpii.0
+```
+
+### Manually
+
+Run `make` to see all available steps.
+
+- `make build` to build image as latest
+- `make push` to push this image to registry


### PR DESCRIPTION
Initial take on certmerge-operator Docker image, which we need for Istio.

Uses multi-stage Docker build to create minimal Docker image from `SCRATCH` that contains just the golang binary.

