### PR TITLE
Upgrade certmerge-operator version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,40 @@
-FROM golang:1.11.5-alpine3.8 AS build
+FROM golang:1.13.6-alpine3.11 AS build
 
-ENV CERTMERGE_RELEASE=v0.0.3 \
-    CERTMERGE_PROJECT=github.com/prune998/certmerge-operator \
-    CERTMERGE_GIT_SHA=20ed30cb4f5acb17f0efeb222acfba3962ab0dd9 \
-    OPERATOR_SDK_RELEASE=v0.4.0 \
-    OPERATOR_SDK_PROJECT=github.com/operator-framework/operator-sdk \
-    OPERATOR_SDK_GIT_SHA=cc5fe885869c181d820557bd296f092637fa70af \
-    DEP_VERSION=v0.5.0 \
-    DEP_SHA=287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f83 \
-    CGO_ENABLED=0 \
+ENV CGO_ENABLED=0 \
     LANG=C.UTF-8
-
-ENV CERTMERGE_GIT_REPO=https://${CERTMERGE_PROJECT}.git \
-    OPERATOR_SDK_GIT_REPO=https://${OPERATOR_SDK_PROJECT}.git \
-    DEP_URL=https://github.com/golang/dep/releases/download/${DEP_VERSION}/dep-linux-amd64
 
 RUN apk add --update --no-cache \
       curl \
       git \
-      make \
-    && curl -LsS "${DEP_URL}" -o /usr/bin/dep \
-    && echo "${DEP_SHA}  /usr/bin/dep" |  sha256sum -c - \
-    && chmod +x /usr/bin/dep \
-    && git clone --branch "${OPERATOR_SDK_RELEASE}" --depth=1 -- "${OPERATOR_SDK_GIT_REPO}" "${GOPATH}/src/${OPERATOR_SDK_PROJECT}" \
-    && cd "${GOPATH}/src/${OPERATOR_SDK_PROJECT}" \
+      grep \
+      make
+
+# operator-sdk
+ENV OPERATOR_SDK_RELEASE=v0.14.1 \
+    OPERATOR_SDK_PROJECT=github.com/operator-framework/operator-sdk \
+    OPERATOR_SDK_GIT_SHA=1c3106afd103ff868bceb9c6a6c077b17bad363c
+
+ENV OPERATOR_SDK_GIT_REPO=https://${OPERATOR_SDK_PROJECT}.git
+
+RUN git clone --branch "${OPERATOR_SDK_RELEASE}" --depth=1 -- "${OPERATOR_SDK_GIT_REPO}" "/src/${OPERATOR_SDK_PROJECT}" \
+    && cd "/src/${OPERATOR_SDK_PROJECT}" \
     && git show-ref --verify HEAD | grep -q "^${OPERATOR_SDK_GIT_SHA}" \
-    && make dep \
-    && make install \
-    && git clone --branch "${CERTMERGE_RELEASE}" --depth=1 -- "${CERTMERGE_GIT_REPO}" "${GOPATH}/src/${CERTMERGE_PROJECT}" \
-    && cd "${GOPATH}/src/${CERTMERGE_PROJECT}" \
+    && make tidy \
+    && make install
+
+# certmerge-operator
+ENV CERTMERGE_RELEASE=v0.0.3-gpii.0 \
+    CERTMERGE_PROJECT=github.com/gpii-ops/certmerge-operator \
+    CERTMERGE_GIT_SHA=d7821bdd9d2defb72f11d5c6b781d0d55817f9d5
+
+ENV CERTMERGE_GIT_REPO=https://${CERTMERGE_PROJECT}.git
+
+
+RUN git clone --branch "${CERTMERGE_RELEASE}" --depth=1 -- "${CERTMERGE_GIT_REPO}" "/src/${CERTMERGE_PROJECT}" \
+    && cd "/src/${CERTMERGE_PROJECT}" \
     && git show-ref --verify HEAD | grep -q "^${CERTMERGE_GIT_SHA}" \
     && operator-sdk generate k8s \
+    && operator-sdk generate crds \
     && go build -o /certmerge-operator cmd/manager/main.go
 
 


### PR DESCRIPTION
This PR upgrades the docker image to the latest version of `certmerge-operator`.

**Changes:**
- Upgrade `certmerge-operator` to latest "gpii" version `v0.0.3-gpii.0`
- Upgrade `operator-sdk` to `v0.14.1`, dependency of the above
- Upgrade build image to newer golang version - `golang:1.13.6-alpine3.11`
- Split build image into multiple steps in order to benefit from caching

Once merged, tag `v0.0.3-gpii.1` should be created.